### PR TITLE
Feature/clw gmi

### DIFF
--- a/src/ufo/filters/obsfunctions/CLWRetMW.cc
+++ b/src/ufo/filters/obsfunctions/CLWRetMW.cc
@@ -32,22 +32,45 @@ CLWRetMW::CLWRetMW(const eckit::LocalConfiguration & conf)
   // Check required parameters
   // Get variable group types for CLW retrieval from option
   ASSERT(options_.varGroup.value().size() == 1 || options_.varGroup.value().size() == 2);
+  ASSERT((options_.ch238.value() != boost::none && options_.ch314.value() != boost::none) ||
+         (options_.ch37v.value() != boost::none && options_.ch37h.value() != boost::none));
 
-  // Get channels for CLW retrieval from options
-  const std::vector<int> channels_ = {options_.ch238.value(), options_.ch314.value()};
-  ASSERT(options_.ch238 != 0 && options_.ch314 != 0 && channels_.size() == 2);
+  if (options_.ch238.value() != boost::none && options_.ch314.value() != boost::none) {
+    // For AMSUA and ATMS retrievals
+    // Get channels for CLW retrieval from options
+    const std::vector<int> channels_ = {options_.ch238.value().get(), options_.ch314.value().get()};
+    ASSERT(options_.ch238.value().get() != 0 && options_.ch314.value().get() != 0
+           && channels_.size() == 2);
+    // Include list of required data from ObsSpace
+    for (size_t igrp = 0; igrp < options_.varGroup.value().size(); ++igrp) {
+      invars_ += Variable("brightness_temperature@" + options_.varGroup.value()[igrp], channels_);
+    }
+    invars_ += Variable("brightness_temperature@" + options_.testBias.value(), channels_);
+    invars_ += Variable("sensor_zenith_angle@MetaData");
 
-  // Include list of required data from ObsSpace
-  for (size_t igrp = 0; igrp < options_.varGroup.value().size(); ++igrp) {
-    invars_ += Variable("brightness_temperature@" + options_.varGroup.value()[igrp], channels_);
+    // Include list of required data from GeoVaLs
+    invars_ += Variable("average_surface_temperature_within_field_of_view@GeoVaLs");
+    invars_ += Variable("water_area_fraction@GeoVaLs");
+    invars_ += Variable("surface_temperature_where_sea@GeoVaLs");
+
+  } else if (options_.ch37v.value() != boost::none && options_.ch37h.value() != boost::none) {
+    // For cloud index like GMI's.
+    // Get channels for CLW retrieval from options
+    const std::vector<int> channels_ = {options_.ch37v.value().get(), options_.ch37h.value().get()};
+
+    ASSERT(options_.ch37v.value().get() != 0 && options_.ch37h.value().get() != 0 &&
+           channels_.size() == 2);
+    // Include list of required data from ObsSpace
+    for (size_t igrp = 0; igrp < options_.varGroup.value().size(); ++igrp) {
+      invars_ += Variable("brightness_temperature@" + options_.varGroup.value()[igrp], channels_);
+    }
+    invars_ += Variable("brightness_temperature@" + options_.testBias.value(), channels_);
+    // Include list of required data from ObsDiag
+    invars_ += Variable("brightness_temperature_assuming_clear_sky@ObsDiag" , channels_);
+
+    // Include list of required data from GeoVaLs
+    invars_ += Variable("water_area_fraction@GeoVaLs");
   }
-  invars_ += Variable("brightness_temperature@" + options_.testBias.value(), channels_);
-  invars_ += Variable("sensor_zenith_angle@MetaData");
-
-  // Include list of required data from GeoVaLs
-  invars_ += Variable("average_surface_temperature_within_field_of_view@GeoVaLs");
-  invars_ += Variable("water_area_fraction@GeoVaLs");
-  invars_ += Variable("surface_temperature_where_sea@GeoVaLs");
 }
 
 // -----------------------------------------------------------------------------
@@ -60,60 +83,112 @@ void CLWRetMW::compute(const ObsFilterData & in,
                                     ioda::ObsDataVector<float> & out) const {
   // Get required parameters
   const std::vector<std::string> &vargrp = options_.varGroup.value();
-  const std::vector<int> channels_ = {options_.ch238.value(), options_.ch314.value()};
 
   // Get dimension
   const size_t nlocs = in.nlocs();
   const size_t ngrps = vargrp.size();
 
-  // Get variables from ObsSpace
-  // Get sensor zenith angle
-  std::vector<float> szas(nlocs);
-  in.get(Variable("sensor_zenith_angle@MetaData"), szas);
-
-  // Get variables from GeoVaLs
-  // Get average surface temperature in FOV
-  std::vector<float> tsavg(nlocs);
-  in.get(Variable("average_surface_temperature_within_field_of_view@GeoVaLs"), tsavg);
-
   // Get area fraction of each surface type
   std::vector<float> water_frac(nlocs);
   in.get(Variable("water_area_fraction@GeoVaLs"), water_frac);
 
-  // Calculate retrieved cloud liquid water
-  std::vector<float> bt238(nlocs), bt314(nlocs);
-  for (size_t igrp = 0; igrp < ngrps; ++igrp) {
-    // Get data based on group type
-    in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_)[channels_[0]-1], bt238);
-    in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_)[channels_[1]-1], bt314);
-    // Get bias based on group type
-    if (options_.addBias.value() == vargrp[igrp]) {
-      std::vector<float> bias238(nlocs), bias314(nlocs);
-      if (in.has(Variable("brightness_temperature@" + options_.testBias.value(), channels_)[0])) {
-      in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
-                      [channels_[0]-1], bias238);
-      in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
-                      [channels_[1]-1], bias314);
-      } else {
-      bias238.assign(nlocs, 0.0f);
-      bias314.assign(nlocs, 0.0f);
-      }
-      // Add bias correction to the assigned group
-      if (options_.addBias.value() == "ObsValue") {
-        for (size_t iloc = 0; iloc < nlocs; ++iloc) {
-          bt238[iloc] = bt238[iloc] - bias238[iloc];
-          bt314[iloc] = bt314[iloc] - bias314[iloc];
-        }
-      } else {
-        for (size_t iloc = 0; iloc < nlocs; ++iloc) {
-          bt238[iloc] = bt238[iloc] + bias238[iloc];
-          bt314[iloc] = bt314[iloc] + bias314[iloc];
-        }
-      }
-    }
+  // --------------- amsua or atms --------------------------
+  if (options_.ch238.value() != boost::none && options_.ch314.value() != boost::none) {
+    const std::vector<int> channels_ = {options_.ch238.value().get(), options_.ch314.value().get()};
 
-    // Compute the cloud liquid qater
-    cloudLiquidWater(szas, tsavg, water_frac, bt238, bt314, out[igrp], nlocs);
+    // Get variables from ObsSpace
+    // Get sensor zenith angle
+    std::vector<float> szas(nlocs);
+    in.get(Variable("sensor_zenith_angle@MetaData"), szas);
+
+    // Get variables from GeoVaLs
+    // Get average surface temperature in FOV
+    std::vector<float> tsavg(nlocs);
+    in.get(Variable("average_surface_temperature_within_field_of_view@GeoVaLs"), tsavg);
+
+    // Calculate retrieved cloud liquid water
+    std::vector<float> bt238(nlocs), bt314(nlocs);
+    for (size_t igrp = 0; igrp < ngrps; ++igrp) {
+      // Get data based on group type
+      in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_)[channels_[0]-1], bt238);
+      in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_)[channels_[1]-1], bt314);
+      // Get bias based on group type
+      if (options_.addBias.value() == vargrp[igrp]) {
+        std::vector<float> bias238(nlocs), bias314(nlocs);
+        if (in.has(Variable("brightness_temperature@" + options_.testBias.value(), channels_)[0])) {
+        in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
+                        [channels_[0]-1], bias238);
+        in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
+                        [channels_[1]-1], bias314);
+        } else {
+        bias238.assign(nlocs, 0.0f);
+        bias314.assign(nlocs, 0.0f);
+        }
+        // Add bias correction to the assigned group
+        if (options_.addBias.value() == "ObsValue") {
+          for (size_t iloc = 0; iloc < nlocs; ++iloc) {
+            bt238[iloc] = bt238[iloc] - bias238[iloc];
+            bt314[iloc] = bt314[iloc] - bias314[iloc];
+          }
+        } else {
+          for (size_t iloc = 0; iloc < nlocs; ++iloc) {
+            bt238[iloc] = bt238[iloc] + bias238[iloc];
+            bt314[iloc] = bt314[iloc] + bias314[iloc];
+          }
+        }
+      }
+
+      // Compute the cloud liquid qater
+      cloudLiquidWater(szas, tsavg, water_frac, bt238, bt314, out[igrp], nlocs);
+    }
+  // -------------------- GMI ---------------------------
+  } else if (options_.ch37v.value() != boost::none && options_.ch37h.value() != boost::none) {
+    const std::vector<int> channels_ = {options_.ch37v.value().get(), options_.ch37h.value().get()};
+    // Indices of data at channeles 37v and 37h in the above array "channels_"
+    int jch37v = 0;
+    int jch37h = 1;
+    std::vector<float> bt_clr_37v(nlocs), bt_clr_37h(nlocs);
+    in.get(Variable("brightness_temperature_assuming_clear_sky@ObsDiag" , channels_)
+           [jch37v], bt_clr_37v);
+    in.get(Variable("brightness_temperature_assuming_clear_sky@ObsDiag" , channels_)
+           [jch37h], bt_clr_37h);
+    // Calculate retrieved cloud liquid water
+    std::vector<float> bt37v(nlocs), bt37h(nlocs);
+    for (size_t igrp = 0; igrp < ngrps; ++igrp) {
+      // Get data based on group type
+      in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_) [jch37v], bt37v);
+      in.get(Variable("brightness_temperature@" + vargrp[igrp], channels_) [jch37h], bt37h);
+      // Get bias based on group type
+      if (options_.addBias.value() == vargrp[igrp]) {
+        std::vector<float> bias37v(nlocs), bias37h(nlocs);
+        if (in.has(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
+            [jch37v])) {
+          in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
+                 [jch37v], bias37v);
+          in.get(Variable("brightness_temperature@" + options_.testBias.value(), channels_)
+                 [jch37h], bias37h);
+        } else {
+        bias37v.assign(nlocs, 0.0f);
+        bias37h.assign(nlocs, 0.0f);
+        }
+        // Add bias correction to the assigned group
+        if (options_.addBias.value() == "ObsValue") {
+          for (size_t iloc = 0; iloc < nlocs; ++iloc) {
+            bt37v[iloc] = bt37v[iloc] - bias37v[iloc];
+            bt37h[iloc] = bt37h[iloc] - bias37h[iloc];
+          }
+        } else {
+          for (size_t iloc = 0; iloc < nlocs; ++iloc) {
+            bt37v[iloc] = bt37v[iloc] + bias37v[iloc];
+            bt37h[iloc] = bt37h[iloc] + bias37h[iloc];
+          }
+        }
+      }
+
+
+      // Compute the cloud liquid qater
+      cloudLiquidWater_gmi(bt_clr_37v, bt_clr_37h, water_frac, bt37v, bt37h, out[igrp], nlocs);
+    }
   }
 }
 
@@ -154,6 +229,37 @@ void CLWRetMW::cloudLiquidWater(const std::vector<float> & szas,
 
 // -----------------------------------------------------------------------------
 
+// -----------------------------------------------------------------------------
+
+void CLWRetMW::cloudLiquidWater_gmi(const std::vector<float> & bt_clr_37v,
+                                         const std::vector<float> & bt_clr_37h,
+                                         const std::vector<float> & water_frac,
+                                         const std::vector<float> & bt37v,
+                                         const std::vector<float> & bt37h,
+                                         std::vector<float> & out,
+                                         const std::size_t nlocs) {
+  ///
+  /// \Retrieve cloud index from GMI 37V and 37H channels.
+  ///
+  /// GMI cloud index: 1.0 - (Tb_37v - Tb_37h)/(Tb_37v_clr - Tb_37h_clr), in which
+  /// Tb_37v_clr and Tb_37h_clr for calculated Tb at 37 V and 37H GHz from module values
+  /// assuming in clear-sky condition. Tb_37v and Tb_37h are Tb observations at 37 V and 37H GHz.
+  ///
+  for (size_t iloc = 0; iloc < nlocs; ++iloc) {
+    if (water_frac[iloc] >= 0.99) {
+      if (bt37h[iloc] <= bt37v[iloc]) {
+        out[iloc] = 1.0 - (bt37v[iloc] - bt37h[iloc])/(bt_clr_37v[iloc] - bt_clr_37h[iloc]);
+        out[iloc] = std::max(0.f, out[iloc]);
+      } else {
+        out[iloc] = getBadValue();
+      }
+    } else {
+      out[iloc] = getBadValue();
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
 const ufo::Variables & CLWRetMW::requiredVariables() const {
   return invars_;
 }

--- a/src/ufo/filters/obsfunctions/CLWRetMW.h
+++ b/src/ufo/filters/obsfunctions/CLWRetMW.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
 #include "oops/util/parameters/Parameters.h"
 #include "oops/util/parameters/RequiredParameter.h"
@@ -33,13 +34,13 @@ class CLWRetMWParameters : public oops::Parameters {
   /// of cloud liquid water applies
   /// Example: AMSU-A channel numbers used in cloud liquid water retrieval
   ///          clwret_channels: 1
-  oops::RequiredParameter<int> ch238{"clwret_ch238", this};
+  oops::OptionalParameter<int> ch238{"clwret_ch238", this};
 
   /// channel number corresponding to 31.4 GHz to which the retrieval
   /// of cloud liquid water applies
   /// Example: AMSU-A channel numbers used in cloud liquid water retrieval
   ///          clwret_channels: 2
-  oops::RequiredParameter<int> ch314{"clwret_ch314", this};
+  oops::OptionalParameter<int> ch314{"clwret_ch314", this};
 
   /// Names of the data group used to retrieve the cloud liquid water
   /// Example: get retrieved CLW from observation and simulated observation respectively
@@ -60,6 +61,12 @@ class CLWRetMWParameters : public oops::Parameters {
   /// Example: use observation bias correction values from GSI
   ///          test_bias: GsiObsBias
   oops::Parameter<std::string> testBias{"test_bias", "ObsBias", this};
+
+  /// GMI cloud index: 1.0 - (Tb_37v - Tb_37h)/(Tb_37v_clr - Tb_37h_clr), which is used in
+  /// all-sky DA. Tb_37v_clr and Tb_37h_clr for calculated Tb at 37V and 37H GHz from model values
+  /// assuming in clear-sky condition. Tb_37v and Tb_37h are Tb observations at 37 V and 37H GHz.
+  oops::OptionalParameter<int> ch37h{"clwret_ch37h", this};
+  oops::OptionalParameter<int> ch37v{"clwret_ch37v", this};
 };
 
 ///
@@ -89,7 +96,15 @@ class CLWRetMW : public ObsFunctionBase {
                                const std::vector<float> &,
                                std::vector<float> &,
                                const std::size_t);
+  static void cloudLiquidWater_gmi(const std::vector<float> &,
+                               const std::vector<float> &,
+                               const std::vector<float> &,
+                               const std::vector<float> &,
+                               const std::vector<float> &,
+                               std::vector<float> &,
+                               const std::size_t);
   inline static float getBadValue() {return bad_clwret_value_;}
+
  private:
   ufo::Variables invars_;
   CLWRetMWParameters options_;

--- a/test/testinput/gmi_crtm.yaml
+++ b/test/testinput/gmi_crtm.yaml
@@ -28,3 +28,19 @@ observations:
     coef TL: 1.e-3
     tolerance TL: 1.0e-3
     tolerance AD: 1.0e-11
+  obs filters:
+  #  CLW Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: 1-13
+    test variables:
+    - name: CLWRetMW@ObsFunction
+      options:
+        clwret_ch37v: 6
+        clwret_ch37h: 7
+        clwret_types: [ObsValue]
+    maxvalue: 999.0
+    action:
+      name: reject
+


### PR DESCRIPTION
Added a cloud retrieval function for GMI radiance data. Polarization differences at 37V and 37H Ghz are used in this function:
              1.0 - (Tb_37v - Tb_37h)/(Tb_37v_clr - Tb_37h_clr), 
where Tb_37v_clr and Tb_37h_clr for calculated Tb at 37V and 37H GHz from model values assuming in clear-sky condition, Tb_37v and Tb_37h are Tb observations at 37 V and 37H GHz. This function is used for assimilation GMI data in all-sky conditions in GEOS system. 
      Some variables for AMSU-A and ATMS clouds function in CLWRetMW.cc and CLWRetMW.h are edited. However, these changes have no impact in those UFO tests with AMSU-A or ATMS.