### PR TITLE
make sure output files don't write into test data dirs

### DIFF
--- a/test/testinput/amsua_qc.yaml
+++ b/test/testinput/amsua_qc.yaml
@@ -47,7 +47,7 @@ observations:
       channels: 1
     threshold: 2.0
   - filter: YDIAGsaver
-    filename: Data/ufo/testinput_tier_1/amsua_n19_ydiag_2018041500_m_out.nc4
+    filename: Data/amsua_n19_ydiag_2018041500_m_out.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: 1-3


### PR DESCRIPTION
## Description

@rhoneyager noted that the following ufo tests could fail if test data is in directory not owned by user:
>  882 - test_ufo_qc_amsua (Failed)
    890 - test_ufo_qc_function_scattering (Failed)

I decided it's likely because the `YDIAGsaver` filter in `amsua_qc.yaml` (used by both of the failing tests) tries to output into the ufo test data directory (my bad, I was doing massive search-and-replace for filenames in one of the previous PRs, and missed that this one should not go into the test data).
I have not tested this, but hopefully this would solve the issue.