### PR TITLE
Adding files for RatioCheck QC filter

### DIFF
--- a/src/ufo/filters/CMakeLists.txt
+++ b/src/ufo/filters/CMakeLists.txt
@@ -20,6 +20,8 @@ set ( filters_files
       BlackList.h
       DifferenceCheck.cc
       DifferenceCheck.h
+      RatioCheck.cc
+      RatioCheck.h
       FilterBase.cc
       FilterBase.h
       getScalarOrFilterData.cc

--- a/src/ufo/filters/QCflags.h
+++ b/src/ufo/filters/QCflags.h
@@ -27,6 +27,7 @@ namespace QCflags {
   constexpr int buddy   = 13;  // observation rejected by the buddy check
   constexpr int derivative = 14;  // observation removed due to metadata derivative value
   constexpr int profile = 15;  // observation rejected by at least one profile QC check
+  constexpr int ratioref = 16;   // ratio of two values outside of range};  // namespace QCflags
 };  // namespace QCflags
 
 }  // namespace ufo

--- a/src/ufo/filters/QCmanager.cc
+++ b/src/ufo/filters/QCmanager.cc
@@ -109,6 +109,7 @@ void QCmanager::print(std::ostream & os) const {
     size_t iseaice  = 0;
     size_t itrack   = 0;
     size_t ibuddy   = 0;
+    size_t iratioref = 0;
 
     for (size_t jobs = 0; jobs < iobs; ++jobs) {
       if ((*flags_)[jj][jobs] == QCflags::pass)    ++ipass;
@@ -128,6 +129,7 @@ void QCmanager::print(std::ostream & os) const {
       if ((*flags_)[jj][jobs] == QCflags::track)  ++itrack;
       if ((*flags_)[jj][jobs] == QCflags::buddy)  ++ibuddy;
       if ((*flags_)[jj][jobs] == QCflags::derivative) ++idydx;
+      if ((*flags_)[jj][jobs] == QCflags::ratioref) ++iratioref;
     }
 
     if (obsdb_.isDistributed()) {
@@ -149,6 +151,7 @@ void QCmanager::print(std::ostream & os) const {
       obsdb_.comm().allReduceInPlace(itrack,  eckit::mpi::sum());
       obsdb_.comm().allReduceInPlace(ibuddy,  eckit::mpi::sum());
       obsdb_.comm().allReduceInPlace(idydx,   eckit::mpi::sum());
+      obsdb_.comm().allReduceInPlace(iratioref, eckit::mpi::sum());
     }
 
     if (obsdb_.comm().rank() == 0) {
@@ -169,12 +172,12 @@ void QCmanager::print(std::ostream & os) const {
       if (iseaice  > 0) os << info << iseaice  << " removed by sea ice check." << std::endl;
       if (itrack   > 0) os << info << itrack  << " removed by track check." << std::endl;
       if (ibuddy   > 0) os << info << ibuddy  << " removed by buddy check." << std::endl;
-
+      if (iratioref   > 0) os << info << iratioref  << " rejected by ratio check." << std::endl;
       os << info << ipass << " passed out of " << iobs << " observations." << std::endl;
     }
 
     ASSERT(ipass + imiss + ipreq + ibnds + iwhit + iblck + iherr + ithin + iclw + iprof + ifgss + \
-           ignss + idiffref + iseaice + itrack + ibuddy + idydx == iobs);
+           ignss + idiffref + iseaice + itrack + ibuddy + idydx + iratioref == iobs);
   }
 }
 

--- a/src/ufo/filters/RatioCheck.cc
+++ b/src/ufo/filters/RatioCheck.cc
@@ -1,0 +1,95 @@
+/*
+ * (C) Copyright 2017-2018 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "ufo/filters/RatioCheck.h"
+
+#include <cmath>
+#include <vector>
+
+#include "eckit/config/Configuration.h"
+
+#include "ioda/ObsDataVector.h"
+#include "ioda/ObsSpace.h"
+
+#include "oops/util/Logger.h"
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+
+RatioCheck::RatioCheck(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+                                 std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                                 std::shared_ptr<ioda::ObsDataVector<float> > obserr)
+  : FilterBase(obsdb, config, flags, obserr),
+    ref_(config_.getString("reference")), val_(config_.getString("value"))
+{
+  oops::Log::trace() << "RatioCheck contructor starting" << std::endl;
+  allvars_ += ref_;
+  allvars_ += val_;
+}
+
+// -----------------------------------------------------------------------------
+
+RatioCheck::~RatioCheck() {
+  oops::Log::trace() << "RatioCheck destructed" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void RatioCheck::applyFilter(const std::vector<bool> & apply,
+                                  const Variables & filtervars,
+                                  std::vector<std::vector<bool>> & flagged) const {
+  oops::Log::trace() << "RatioCheck priorFilter" << std::endl;
+
+  const float missing = util::missingValue(missing);
+  const size_t nlocs = obsdb_.nlocs();
+
+// min/max value setup
+  float vmin = config_.getFloat("minvalue", missing);
+  float vmax = config_.getFloat("maxvalue", missing);
+
+// check if threshold should be absolute or not
+  const bool absval = config_.getBool("absolute", false);
+
+// Get reference values and values to compare (as floats)
+  std::vector<float> ref, val;
+  data_.get(ref_, ref);
+  data_.get(val_, val);
+  ASSERT(ref.size() == val.size());
+
+// Loop over all obs
+  for (size_t jobs = 0; jobs < nlocs; ++jobs) {
+    if (apply[jobs]) {
+      // check to see if one of the reference or value is missing
+      if (val[jobs] == missing || ref[jobs] == missing || ref[jobs] == 0) {
+        for (size_t jv = 0; jv < filtervars.nvars(); ++jv) {
+          flagged[jv][jobs] = true;
+        }
+      } else {
+// Check if the ratio of val/ref is within min/max range and set flag
+        float ratio = val[jobs] / ref[jobs];
+        if (absval) {
+          ratio = fabs(ratio);
+        }
+        for (size_t jv = 0; jv < filtervars.nvars(); ++jv) {
+          if (vmin != missing && ratio < vmin) flagged[jv][jobs] = true;
+          if (vmax != missing && ratio > vmax) flagged[jv][jobs] = true;
+        }
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void RatioCheck::print(std::ostream & os) const {
+  os << "RatioCheck::print not yet implemented ";
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo

--- a/src/ufo/filters/RatioCheck.h
+++ b/src/ufo/filters/RatioCheck.h
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright 2019 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UFO_FILTERS_RATIOCHECK_H_
+#define UFO_FILTERS_RATIOCHECK_H_
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "oops/util/ObjectCounter.h"
+#include "ufo/filters/FilterBase.h"
+#include "ufo/filters/QCflags.h"
+#include "ufo/filters/Variable.h"
+
+namespace eckit {
+  class Configuration;
+}
+
+namespace ioda {
+  template <typename DATATYPE> class ObsDataVector;
+  class ObsSpace;
+}
+
+namespace ufo {
+
+/// RatioCheck filter
+
+class RatioCheck : public FilterBase,
+                        private util::ObjectCounter<RatioCheck> {
+ public:
+  static const std::string classname() {return "ufo::RatioCheck";}
+
+  RatioCheck(ioda::ObsSpace &, const eckit::Configuration &,
+                  std::shared_ptr<ioda::ObsDataVector<int> >,
+                  std::shared_ptr<ioda::ObsDataVector<float> >);
+  ~RatioCheck();
+
+ private:
+  void print(std::ostream &) const override;
+  void applyFilter(const std::vector<bool> &, const Variables &,
+                   std::vector<std::vector<bool>> &) const override;
+  int qcFlag() const override {return QCflags::ratioref;}
+  const Variable ref_;
+  const Variable val_;
+};
+
+}  // namespace ufo
+
+#endif  // UFO_FILTERS_RATIOCHECK_H_

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -25,6 +25,7 @@
 #include "ufo/filters/PreQC.h"
 #include "ufo/filters/ProfileConsistencyChecks.h"
 #include "ufo/filters/QCmanager.h"
+#include "ufo/filters/RatioCheck.h"
 #include "ufo/filters/TemporalThinning.h"
 #include "ufo/filters/Thinning.h"
 #include "ufo/filters/TrackCheck.h"
@@ -47,6 +48,8 @@ template<typename MODEL> void instantiateObsFilterFactory() {
            blackListMaker("BlackList");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::BackgroundCheck> >
            backgroundCheckMaker("Background Check");
+  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::RatioCheck> >
+           ratioCheckMaker("Ratio Check");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::DifferenceCheck> >
            differenceCheckMaker("Difference Check");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::ROobserror> >

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,6 +144,7 @@ list( APPEND ufo_test_input
   testinput/qc_derivative_dpdt.yaml
   testinput/qc_derivative_dxdt.yaml
   testinput/qc_differencecheck.yaml
+  testinput/qc_ratiocheck.yaml
   testinput/qc_gauss_thinning.yaml
   testinput/qc_gauss_thinning_unittests.yaml
   testinput/qc_met_office_buddy_check.yaml
@@ -1134,6 +1135,13 @@ ecbuild_add_test( TARGET  test_ufo_qc_gen_defer_to_post
 ecbuild_add_test( TARGET  test_ufo_qc_gen_differencecheck
                   COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
                   ARGS    "testinput/qc_differencecheck.yaml"
+                  ENVIRONMENT OOPS_TRAPFPE=1
+                  DEPENDS test_ObsFilters.x
+                  TEST_DEPENDS ufo_get_ufo_test_data )
+
+ecbuild_add_test( TARGET  test_ufo_qc_gen_ratiocheck
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
+                  ARGS    "testinput/qc_ratiocheck.yaml"
                   ENVIRONMENT OOPS_TRAPFPE=1
                   DEPENDS test_ObsFilters.x
                   TEST_DEPENDS ufo_get_ufo_test_data )

--- a/test/testinput/qc_ratiocheck.yaml
+++ b/test/testinput/qc_ratiocheck.yaml
@@ -1,0 +1,29 @@
+window begin: 2018-01-01T00:00:00Z
+window end: 2019-01-01T00:00:00Z
+observations:
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1]
+  obs filters:
+  - filter: Ratio Check   # test min and maxvalue of ratio of var2/var1
+    filter variables:
+    - name: variable1
+    value: variable2@ObsValue       # 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+    reference: variable1@ObsValue   # 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+    minvalue: 1.1
+    maxvalue: 1.45
+    absolute: true    # does not matter here but showing for syntax
+  passedBenchmark: 7
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1]
+  obs filters:
+  - filter: Ratio Check    # compare var3/var4 with min
+    value: var3@MetaData        # var3@MetaData = 1, 1, 1, 1, 1, 0, 0, 0, 0, 0
+    reference: var4@MetaData    # var4@MetaData = 0, 0, 0, 0, 0, 1, 2, 3, 4, 5
+    minvalue: 0.5
+  passedBenchmark: 0


### PR DESCRIPTION
## Description

This PR adds a new QC filter "RatioCheck".
Adds a new ctest: test_ufo_qc_gen_ratiocheck
It checks to ignore "0" values in the denominator.

![image](https://user-images.githubusercontent.com/26145004/101840642-7bf47300-3b12-11eb-846e-78218ccfc64f.png)


### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Dependencies
No


