### PR TITLE
Added BoundsCheck Filter in UFO tests

### DIFF
--- a/src/ufo/filters/CMakeLists.txt
+++ b/src/ufo/filters/CMakeLists.txt
@@ -62,6 +62,8 @@ set ( filters_files
       QCmanager.h
       PerformAction.cc
       PerformAction.h
+      PracticalBoundsCheck.cc
+      PracticalBoundsCheck.h
       ProfileBackgroundCheck.cc
       ProfileBackgroundCheck.h
       ProfileConsistencyChecks.cc

--- a/src/ufo/filters/PracticalBoundsCheck.cc
+++ b/src/ufo/filters/PracticalBoundsCheck.cc
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2017-2018 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "ufo/filters/PracticalBoundsCheck.h"
+
+#include <cmath>
+#include <vector>
+
+#include "eckit/config/Configuration.h"
+
+#include "ioda/ObsDataVector.h"
+#include "ioda/ObsSpace.h"
+
+#include "oops/util/Logger.h"
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::PracticalBoundsCheck(ioda::ObsSpace & obsdb, const Parameters_ & parameters,
+                                 std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                                 std::shared_ptr<ioda::ObsDataVector<float> > obserr)
+  : FilterBase(obsdb, parameters, flags, obserr),
+    parameters_(parameters)
+{
+  oops::Log::trace() << "PracticalBoundsCheck contructor starting" << std::endl;
+  allvars_ += parameters_.ref;
+  allvars_ += parameters_.val;
+}
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::~PracticalBoundsCheck() {
+  oops::Log::trace() << "PracticalBoundsCheck destructed" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::applyFilter(const std::vector<bool> & apply,
+                                  const Variables & filtervars,
+                                  std::vector<std::vector<bool>> & flagged) const {
+  oops::Log::trace() << "PracticalBoundsCheck priorFilter" << std::endl;
+
+  ufo::Variables testvars;
+  testvars += ufo::Variables(filtervars, "ObsValue");
+
+  // Retrieve the bounds.
+  const float missing = util::missingValue(missing);
+  const float vmin = parameters_.minvalue.value().value_or(missing);
+  const float vmax = parameters_.maxvalue.value().value_or(missing);
+
+// Sanity checks
+  if (filtervars.nvars() == 0) {
+    oops::Log::error() << "No variables will be filtered out in filter "
+                       << config_ << std::endl;
+    ABORT("No variables specified to be filtered out in filter");
+  }
+
+// Loop over all variables to filter
+    for (size_t jv = 0; jv < testvars.nvars(); ++jv) {
+      //  get test data for this variable
+      std::vector<float> testdata;
+      data_.get(testvars.variable(jv), testdata);
+      //  apply the filter
+      for (size_t jobs = 0; jobs < obsdb_.nlocs(); ++jobs) {
+        if (apply[jobs]) {
+          ASSERT(testdata[jobs] != missing);
+          if (vmin != missing && testdata[jobs] < vmin) flagged[jv][jobs] = true;
+          if (vmax != missing && testdata[jobs] > vmax) flagged[jv][jobs] = true;
+        }
+      }
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::print(std::ostream & os) const {
+  os << "PracticalBoundsCheck::print not yet implemented ";
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo

--- a/src/ufo/filters/PracticalBoundsCheck.h
+++ b/src/ufo/filters/PracticalBoundsCheck.h
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright 2019 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+#define UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "oops/util/ObjectCounter.h"
+#include "oops/util/parameters/OptionalParameter.h"
+#include "oops/util/parameters/RequiredParameter.h"
+#include "ufo/filters/FilterBase.h"
+#include "ufo/filters/QCflags.h"
+#include "ufo/filters/Variable.h"
+#include "ufo/utils/parameters/ParameterTraitsVariable.h"
+
+namespace eckit {
+  class Configuration;
+}
+
+namespace ioda {
+  template <typename DATATYPE> class ObsDataVector;
+  class ObsSpace;
+}
+
+namespace ufo {
+
+/// Parameters controlling the operation of the PracticalBoundsCheck filter.
+class PracticalBoundsCheckParameters : public FilterParametersBase {
+  OOPS_CONCRETE_PARAMETERS(PracticalBoundsCheckParameters, FilterParametersBase)
+
+ public:
+  /// Name of the reference variable.
+  oops::RequiredParameter<Variable> ref{"reference", this};
+  /// Name of the test variable.
+  oops::RequiredParameter<Variable> val{"value", this};
+
+  /// The filter will flag observations for which the difference `test - reference` is below
+  /// `minvalue`.
+  oops::OptionalParameter<float> minvalue{"minvalue", this};
+  /// The filter will flag observations for which the difference `test - reference` is above
+  /// `maxvalue`.
+  oops::OptionalParameter<float> maxvalue{"maxvalue", this};
+
+  /// If the `threshold` option is specified, the filter behaves as if `minvalue` was set to
+  /// `-threshold` and `maxvalue` was set to `threshold` (overriding any values of these options
+  /// specified independently).
+  oops::OptionalParameter<float> threshold{"threshold", this};
+};
+
+/// A filter that compares the difference between a test variable and a reference variable and
+/// flags observations for which this difference is outside of a prescribed range.
+///
+/// See PracticalBoundsCheckParameters for the documentation
+//// of the parameters controlling this filter.
+
+class PracticalBoundsCheck : public FilterBase,
+                        private util::ObjectCounter<PracticalBoundsCheck> {
+ public:
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef PracticalBoundsCheckParameters Parameters_;
+
+  static const std::string classname() {return "ufo::PracticalBoundsCheck";}
+
+  PracticalBoundsCheck(ioda::ObsSpace &, const Parameters_ &,
+                  std::shared_ptr<ioda::ObsDataVector<int> >,
+                  std::shared_ptr<ioda::ObsDataVector<float> >);
+  ~PracticalBoundsCheck();
+
+ private:
+  void print(std::ostream &) const override;
+  void applyFilter(const std::vector<bool> &, const Variables &,
+                   std::vector<std::vector<bool>> &) const override;
+  int qcFlag() const override {return QCflags::bounds;}
+
+  Parameters_ parameters_;
+};
+
+}  // namespace ufo
+
+#endif  // UFO_FILTERS_PRACTICALBOUNDSCHECK_H_

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -30,6 +30,7 @@
 #include "ufo/filters/ObsDomainErrCheck.h"
 #include "ufo/filters/PerformAction.h"
 #include "ufo/filters/PoissonDiskThinning.h"
+#include "ufo/filters/PracticalBoundsCheck.h"
 #include "ufo/filters/PreQC.h"
 #include "ufo/filters/ProfileBackgroundCheck.h"
 #include "ufo/filters/ProfileConsistencyChecks.h"
@@ -137,6 +138,8 @@ template<typename OBS> void instantiateObsFilterFactory() {
            legacyGaussianThinningMaker("Gaussian_Thinning");
   static oops::FilterMaker<OBS, oops::ObsFilter<OBS, ufo::TemporalThinning> >
            legacyTemporalThinningMaker("TemporalThinning");
+  static oops::FilterMaker<OBS, oops::ObsFilter<OBS, ufo::PracticalBoundsCheck> >
+         practicalBoundsCheckMaker("Practical Bounds Check");
 }
 
 }  // namespace ufo

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,6 +186,7 @@ list( APPEND ufo_test_input
   testinput/qc_poisson_disk_thinning.yaml
   testinput/qc_poisson_disk_thinning_unittests.yaml
   testinput/qc_poisson_disk_thinning_parallel.yaml
+  testinput/qc_practical_boundscheck.yaml
   testinput/qc_preqc.yaml
   testinput/qc_preqc_halo.yaml
   testinput/qc_profile_background_check.yaml
@@ -3111,6 +3112,13 @@ ecbuild_add_test( TARGET  test_interpolate_data_from_file_predictor
                   ARGS    "testinput/interpolate_data_from_file_predictor.yaml"
                   ENVIRONMENT OOPS_TRAPFPE=1
                   DEPENDS test_Predictor.x
+                  TEST_DEPENDS ufo_get_ufo_test_data )
+
+ecbuild_add_test( TARGET  test_ufo_qc_gen_practical_boundscheck
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
+                  ARGS    "testinput/qc_practical_boundscheck.yaml"
+                  ENVIRONMENT OOPS_TRAPFPE=1
+                  DEPENDS test_ObsFilters.x
                   TEST_DEPENDS ufo_get_ufo_test_data )
 
 #####################################################################

--- a/test/testinput/qc_practical_boundscheck.yaml
+++ b/test/testinput/qc_practical_boundscheck.yaml
@@ -1,0 +1,40 @@
+window begin: 2018-01-01T00:00:00Z
+window end: 2019-01-01T00:00:00Z
+
+observations:
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1, variable2, variable3]
+  obs filters:
+  - filter: Practical Bounds Check        # test min/max value with all variables
+    filter variables:
+    - name: variable1
+    - name: variable2
+    - name: variable3
+    minvalue: 14.0
+    maxvalue: 19.0
+# Compare variables with minvalue/maxvalue
+#  variable1@ObsValue = 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+  passedBenchmark: 13
+
+  - obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1, variable2, variable3]
+  obs filters:
+  - filter: Practical Bounds Check        # test min/max value with all variables
+    filter variables:
+    - name: variable2
+    - name: variable3
+    minvalue: 15.0
+    maxvalue: 20.0
+# Compare variables with minvalue/maxvalue
+#  variable1@ObsValue = 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+  passedBenchmark: 18


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?
   Added New BoundsCheck Filter in UFO tests with the following changes. 
        modified:   src/ufo/filters/CMakeLists.txt
        new file:   src/ufo/filters/PracticalBoundsCheck.cc
        new file:   src/ufo/filters/PracticalBoundsCheck.h
        modified:   src/ufo/instantiateObsFilterFactory.h
        modified:   test/CMakeLists.txt
        new file:   test/testinput/qc_practical_boundscheck.yaml

## Definition of Done

What does it mean for this issue to be done?  Is there a specific, measurable, milestone?

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [x] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
