### PR TITLE
add logic to handle ObsDtype::Empty cases

### DIFF
--- a/src/ufo/filters/VariableAssignment.cc
+++ b/src/ufo/filters/VariableAssignment.cc
@@ -168,6 +168,11 @@ void assignNumericValues(const AssignmentParameters &params,
       assignVariable<int>(*params.sourceVariable.value(), params.skipDerived,
                           apply, data, values);
       break;
+    case ioda::ObsDtype::Empty:
+      oops::Log::info() << "ufo::VariableAssignment::assignNumericValues "
+			<< params.sourceVariable.value()->fullName()
+			<< " is Empty" << std::endl;
+      break;
     default:
       throw eckit::BadParameter(params.sourceVariable.value()->fullName() +
                                 " is not a numeric variable", Here());
@@ -318,6 +323,10 @@ void assignToVariable(const ufo::Variable &variable,
     break;
   case ioda::ObsDtype::DateTime:
     assignToNonnumericVariable<util::DateTime>(variable, params, apply, data, obsdb);
+    break;
+  case ioda::ObsDtype::Empty:
+    oops::Log::info() << "ufo::VariableAssignment::assignToVariable "
+		      << "received Empty ObsDtype - do nothing" << std::endl;
     break;
   default:
     ASSERT_MSG(false, "Unrecognized data type");

--- a/src/ufo/filters/processWhere.cc
+++ b/src/ufo/filters/processWhere.cc
@@ -648,7 +648,7 @@ std::vector<bool> processWhere(const std::vector<WhereParameters> & params,
             const std::set<int> &bitIndices = *currentParams.anyBitSetOf.value();
             filterdata.get(varname, data);
             processWhereAnyBitSetOf(data, bitIndices, whereTest);
-          } else {
+          } else if (dtype != ioda::ObsDtype::Empty) {
             throw eckit::UserError(
               "Only integer variables may be used for processWhere 'any_bit_set_of'",
               Here());


### PR DESCRIPTION
## Description

add logic to handle `ioda::ObsDtype::Empty` cases in filters

## Issue(s) addressed

Resolves [#3317](https://github.com/JCSDA-internal/ufo/issues/3317) 

## Dependencies

none

## Impact

Allow filters to run when certain ObsDtype are empty

## Checklist

- [ ] I have performed a self-review of my own code

